### PR TITLE
Comment on code example references wrong Layout

### DIFF
--- a/guide/widgets.html
+++ b/guide/widgets.html
@@ -662,7 +662,7 @@ size and pos. We can do that as follows:</p>
         <span class="nc">Color</span><span class="p">:</span>
             <span class="na">rgba</span><span class="p">:</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">1</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">1</span>
         <span class="nc">Rectangle</span><span class="p">:</span>
-            <span class="c1"># self here refers to the widget i.e BoxLayout</span>
+            <span class="c1"># self here refers to the widget i.e FloatLayout</span>
             <span class="na">pos</span><span class="p">:</span> <span class="bp">self</span><span class="o">.</span><span class="n">pos</span>
             <span class="na">size</span><span class="p">:</span> <span class="bp">self</span><span class="o">.</span><span class="n">size</span>
 </pre></div>


### PR DESCRIPTION
There is no BoxLayout anywhere, older examples probably used BoxLayout instead of FloatLayout.